### PR TITLE
Adjust clang-tidy-cache-server for modern flask

### DIFF
--- a/clang-tidy-cache-server
+++ b/clang-tidy-cache-server
@@ -818,7 +818,7 @@ def ctc_static_file(file_name):
         return flask.send_from_directory(
             directory=ctcache_app.config["STATIC_FOLDER"],
             path=file_name,
-            filename=file_name,
+            download_name=file_name,
             as_attachment=False
         )
     except FileNotFoundError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask
+flask >= 2.0.0
 gevent
 WSGIserver
 matplotlib


### PR DESCRIPTION
Parameters for send_from_director that were depreated in Flask 2.0.0 were completely dropped in 2.2.0: https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-2-0

So 'filename' is not a legit name anymore.

I guess it was left in https://github.com/matus-chochlik/ctcache/commit/3ff698f7f87055042cace71321ffc3042337bae3 to be compatible with both modern and old flask. Looks like this is not that easy these days, but maybe now it is ok to require flask >= 2.0.0 and drop legacy parameter name.

And in addition, we can specify `download_name`