### PR TITLE
Add possibility to specify https instead of http via CTCACHE_PROTO

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ variables:
 |`CTCACHE_S3_BUCKET`        |  ✓   |      | the S3 bucket to store cache remotely                    |
 |`CTCACHE_S3_FOLDER`        |  ✓   |      | the prefix directory in S3, w/o leading and trailing `/` |
 |`CTCACHE_S3_NO_CREDENTIALS`|  ✓   |      | if set, script won't try to put objects to S3            |
+|`CTCACHE_PROTO`            |  ✓   |      | protocol for connecting to the server                    |
 |`CTCACHE_HOST`             |  ✓   |  ✓   | hostname or IP address of the server                     |
 |`CTCACHE_PORT`             |  ✓   |  ✓   | listening port of the server                             |
 |`CTCACHE_WEBROOT`          |      |  ✓   | directory containin static server files                  |

--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -191,6 +191,10 @@ class ClangTidyCacheOpts(object):
         return os.getenv("CTCACHE_HOST", "localhost")
 
     # --------------------------------------------------------------------------
+    def rest_proto(self):
+        return int(os.getenv("CTCACHE_PROTO", "http"))
+
+    # --------------------------------------------------------------------------
     def rest_port(self):
         return int(os.getenv("CTCACHE_PORT", 5000))
 
@@ -283,7 +287,8 @@ class ClangTidyServerCache(object):
 
     # --------------------------------------------------------------------------
     def _make_query_url(self, digest):
-        return "http://%(host)s:%(port)d/is_cached/%(digest)s" % {
+        return "%(proto)s://%(host)s:%(port)d/is_cached/%(digest)s" % {
+            "proto": self._opts.rest_proto(),
             "host": self._opts.rest_host(),
             "port": self._opts.rest_port(),
             "digest": digest
@@ -291,7 +296,8 @@ class ClangTidyServerCache(object):
 
     # --------------------------------------------------------------------------
     def _make_store_url(self, digest):
-        return "http://%(host)s:%(port)d/cache/%(digest)s" % {
+        return "%(proto)s://%(host)s:%(port)d/cache/%(digest)s" % {
+            "proto": self._opts.rest_proto(),
             "host": self._opts.rest_host(),
             "port": self._opts.rest_port(),
             "digest": digest
@@ -299,7 +305,8 @@ class ClangTidyServerCache(object):
 
     # --------------------------------------------------------------------------
     def _make_stats_url(self):
-        return "http://%(host)s:%(port)d/stats" % {
+        return "%(proto)s://%(host)s:%(port)d/stats" % {
+            "proto": self._opts.rest_proto(),
             "host": self._opts.rest_host(),
             "port": self._opts.rest_port()
         }


### PR DESCRIPTION
In our infrastructure, we can't use direct http connections even between internal services on different machines. In case of ctcache, all connections go via nginx https proxy which is configured in a way that doesn't accept pure http (`400 Bad Request "the plain http request was sent to https port"`). The easiest way for us to solve this issue is to use 'https' in ctcache when connecting to the server.