### PR TITLE
Do not treat CTCACHE_PROTO as int

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -192,7 +192,7 @@ class ClangTidyCacheOpts(object):
 
     # --------------------------------------------------------------------------
     def rest_proto(self):
-        return int(os.getenv("CTCACHE_PROTO", "http"))
+        return os.getenv("CTCACHE_PROTO", "http")
 
     # --------------------------------------------------------------------------
     def rest_port(self):
@@ -252,6 +252,8 @@ class ClangTidyServerCache(object):
             query = self._requests.get(self._make_query_url(digest), timeout=3)
             if query.status_code == 200:
                 if query.json() == True:
+                    return True
+                elif query.json() == False:
                     return True
                 else:
                     self._log.error("is_cached: Can't connect to server {0}, error {1}".format(

--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -254,7 +254,7 @@ class ClangTidyServerCache(object):
                 if query.json() == True:
                     return True
                 elif query.json() == False:
-                    return True
+                    return False
                 else:
                     self._log.error("is_cached: Can't connect to server {0}, error {1}".format(
                         self._opts.rest_host(), query.status_code))


### PR DESCRIPTION
+ Do not print error message if server returned 'false' string

There was a mistake in my previous PR, CTCACHE_PROTO should not be cast to int.

In addition, the server returns 'false' string if cache not found. When we launch `json()` for such response, we get `False` value. The current code treats this as a server connection error, but this is not correct and looks confusing.