### PR TITLE
Changed the way the hash is created in `hash_inputs()`

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -27,6 +27,22 @@ except ImportError:
 class ClangTidyCacheOpts(object):
     # --------------------------------------------------------------------------
     def __init__(self, log, args):
+        # Define the prefix used to identify directories with clang-tidy
+        prefix = '--directories_with_clang_tidy='
+
+        # Iterate through the command line arguments
+        for index, arg in enumerate(args):
+            if arg.startswith(prefix):
+                # Split the argument using '*' as a separator to get a list of directories, I
+                # used '*' because a folder cannot contain this character in its name whereas
+                # it can contain `,`
+                self._directories_with_clang_tidy = arg[len(prefix):].split('*')
+
+                # Remove the argument because clang-tidy will not like it
+                args.pop(index)
+
+                break
+
         self._original_args = args
         self._clang_tidy_args = []
         self._compiler_args = []
@@ -125,6 +141,10 @@ class ClangTidyCacheOpts(object):
             return self._original_args[0] == "--clean"
         except IndexError:
             return False
+
+    # --------------------------------------------------------------------------
+    def directories_with_clang_tidy(self):
+        return self._directories_with_clang_tidy
 
     # --------------------------------------------------------------------------
     def original_args(self):
@@ -576,9 +596,10 @@ def find_ct_config(search_path):
 
 # ------------------------------------------------------------------------------
 def hash_inputs(opts):
-    co_args = opts.compiler_args()
     ct_args = opts.clang_tidy_args()
-    if not co_args and not ct_args:
+    co_args = opts.compiler_args()
+
+    if not ct_args and not co_args:
         return None
 
     if len(co_args) == 0:
@@ -586,39 +607,45 @@ def hash_inputs(opts):
 
     result = ClangTidyCacheHash(opts)
 
-    proc = subprocess.Popen(
-        co_args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE
-    )
-    stdout, stderr = proc.communicate()
-    if stderr:
+    #==== Source File Modification Time ===========================================#
+
+    source_file_extensions = [".cpp", ".c", ".h", ".hpp", ".cxx"]
+
+    # Find the first valid source file in ct_args
+    for line in ct_args[1:]:
+        if os.path.exists(line) and any(line.lower().endswith(ext) for ext in source_file_extensions):
+            source_file = os.path.normpath(os.path.realpath(line))
+            break
+
+    # Calculate a timestamp-based hash using the modification time of each source file
+    try:
+        mtime = os.path.getmtime(source_file)
+        timestamp_hash = str(int(mtime))
+
+        result.update(timestamp_hash.encode("utf8"))
+    except OSError:
         return None
 
-    src_to_ct_config = dict()
+    #=========== Config Contents ==================================================#
+
+    config_directories = opts.directories_with_clang_tidy()
+
     ct_config_paths = set()
 
-    for line in stdout.splitlines():
-        line = line.decode("utf8")
-        search_path = source_file_changed(line)
-        if search_path:
-            try:
-                ct_config_path = src_to_ct_config[search_path]
-            except KeyError:
-                ct_config_path = find_ct_config(search_path)
-                src_to_ct_config[search_path] = ct_config_path
+    for directory in config_directories:
+        directory = os.path.normpath(directory.strip())  # Normalize and remove whitespace
+        common_path = os.path.commonpath([source_file, directory])
 
-            if ct_config_path:
-                ct_config_paths.add(ct_config_path)
+        if common_path == directory:
+            ct_config_paths.add(os.path.join(directory, '.clang-tidy'))
 
-        chunk = opts.adjust_chunk(line)
-        result.update(chunk)
-
-    for ct_config_path in sorted(ct_config_paths):
-        with open(ct_config_path, "rt") as ct_config:
-            for line in ct_config.readlines():
+    for ct_config in sorted(ct_config_paths):
+        with open(ct_config, "rt") as ct_config:
+            for line in ct_config:
                 chunk = opts.adjust_chunk(line)
                 result.update(chunk)
+
+    #==== Clang-Tidy and Compiler Args ============================================#
 
     def _omit_after(args, excl):
         omit_next = False
@@ -630,9 +657,10 @@ def hash_inputs(opts):
 
     ct_args = list(_omit_after(ct_args, ["-export-fixes"]))
 
-    for chunk in sorted(set([opts.adjust_chunk(arg) for arg in co_args[1:]])):
-        result.update(chunk)
     for chunk in sorted(set([opts.adjust_chunk(arg) for arg in ct_args[1:]])):
+        result.update(chunk)
+
+    for chunk in sorted(set([opts.adjust_chunk(arg) for arg in co_args[1:]])):
         result.update(chunk)
 
     return result.hexdigest()

--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -27,6 +27,8 @@ except ImportError:
 class ClangTidyCacheOpts(object):
     # --------------------------------------------------------------------------
     def __init__(self, log, args):
+        self._directories_with_clang_tidy = []
+        
         # Define the prefix used to identify directories with clang-tidy
         prefix = '--directories_with_clang_tidy='
 
@@ -629,7 +631,7 @@ def hash_inputs(opts):
     #=========== Config Contents ==================================================#
 
     config_directories = opts.directories_with_clang_tidy()
-
+    
     ct_config_paths = set()
 
     for directory in config_directories:

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at
 #  http://www.boost.org/LICENSE_1_0.txt
-#
+
 cmake_minimum_required(VERSION 3.10)
 project(ctcache-example VERSION 1.0)
 
@@ -10,9 +10,50 @@ find_program(CLANG_TIDY_COMMAND clang-tidy)
 
 add_executable(bad01 bad01.cpp)
 target_compile_options(bad01 PRIVATE -pedantic;-Wall;-Werror)
+
 if(CLANG_TIDY_COMMAND)
-    set_target_properties(
-        bad01 PROPERTIES
-        CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND}
-    )
+    function(find_all_directories_with_clang_tidy VARIABLE)
+        file(GLOB CLANG_TIDY_FILES "${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy")
+
+        if(CLANG_TIDY_FILES)
+            list(APPEND DIRECTORIES_WITH_CLANG_TIDY ${CMAKE_CURRENT_SOURCE_DIR})
+        endif()
+
+        file(GLOB ALL_PROJECT_FILES
+             LIST_DIRECTORIES true
+             "${CMAKE_CURRENT_SOURCE_DIR}/*"
+        )
+
+        foreach(DIRECTORY ${ALL_PROJECT_FILES})
+            if(IS_DIRECTORY ${DIRECTORY})
+                get_filename_component(DIR_NAME ${DIRECTORY} NAME)
+
+                if(NOT DIR_NAME STREQUAL "build")
+                    # Check if the directory contains a .clang-tidy file
+                    file(GLOB CLANG_TIDY_FILES "${DIRECTORY}/.clang-tidy")
+
+                    # If so, add the directory to `DIRECTORIES_WITH_CLANG_TIDY`
+                    if(CLANG_TIDY_FILES)
+                        list(APPEND DIRECTORIES_WITH_CLANG_TIDY ${DIRECTORY})
+                    endif()
+                endif()
+            endif()
+        endforeach()
+
+        # CMake splits args up with ";" so use "*" to keep all the directories together, folders can't contain "*" in their name so this should be safe
+        string(REPLACE ";" "*" DIRECTORIES_WITH_CLANG_TIDY "${DIRECTORIES_WITH_CLANG_TIDY}")
+
+        set(${VARIABLE}
+            ${DIRECTORIES_WITH_CLANG_TIDY}
+            PARENT_SCOPE
+        )
+    endfunction()
+
+    find_all_directories_with_clang_tidy(DIRECTORIES_WITH_CLANG_TIDY)
+
+    if(DIRECTORIES_WITH_CLANG_TIDY)
+        set_target_properties(bad01 PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND} --directories_with_clang_tidy=${DIRECTORIES_WITH_CLANG_TIDY})
+    else()
+        set_target_properties(bad01 PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND})
+    endif()
 endif()


### PR DESCRIPTION
I changed the way the hash is created in `hash_inputs()` because building a project with VSCode and Ninja outputs many thousands of lines of code when running this part of the original code:
```python
    proc = subprocess.Popen(
        co_args,
        stdout=subprocess.PIPE,
        stderr=subprocess.PIPE
    )
    stdout, stderr = proc.communicate()
    if stderr:
        return None
```
which causes the project to hang indefinately.

I also noticed that `stdout` and `stderr` get switched around when compiling with cl.exe vs clang.exe although I can no longer be sure that was the case.

The method now calculates the hash with the time the source file was last modified, the lines within any .clang-tidy config files, and then the args. The last two are more or less the same as the original code although the method I use to find the .clang-tidy is different and requires a new arg to be passed to clang-tidy: `--directories_with_clang_tidy=<file1*file2*...>`. This can be achieved in CMake with the following code:
```cmake
cmake_minimum_required(VERSION 3.10)
project(ctcache-example VERSION 1.0)

find_program(CLANG_TIDY_COMMAND clang-tidy)

add_executable(bad01 bad01.cpp)
target_compile_options(bad01 PRIVATE -pedantic;-Wall;-Werror)

if(CLANG_TIDY_COMMAND)
    function(find_all_directories_with_clang_tidy VARIABLE)
        file(GLOB CLANG_TIDY_FILES "${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy")

        if(CLANG_TIDY_FILES)
            list(APPEND DIRECTORIES_WITH_CLANG_TIDY ${CMAKE_CURRENT_SOURCE_DIR})
        endif()

        file(GLOB ALL_PROJECT_FILES
             LIST_DIRECTORIES true
             "${CMAKE_CURRENT_SOURCE_DIR}/*"
        )

        foreach(DIRECTORY ${ALL_PROJECT_FILES})
            if(IS_DIRECTORY ${DIRECTORY})
                get_filename_component(DIR_NAME ${DIRECTORY} NAME)

                if(NOT DIR_NAME STREQUAL "build")
                    # Check if the directory contains a .clang-tidy file
                    file(GLOB CLANG_TIDY_FILES "${DIRECTORY}/.clang-tidy")

                    # If so, add the directory to `DIRECTORIES_WITH_CLANG_TIDY`
                    if(CLANG_TIDY_FILES)
                        list(APPEND DIRECTORIES_WITH_CLANG_TIDY ${DIRECTORY})
                    endif()
                endif()
            endif()
        endforeach()

        # CMake splits args up with ";" so use "*" to keep all the directories together, folders can't contain "*" in their name so this should be safe
        string(REPLACE ";" "*" DIRECTORIES_WITH_CLANG_TIDY "${DIRECTORIES_WITH_CLANG_TIDY}")

        set(${VARIABLE}
            ${DIRECTORIES_WITH_CLANG_TIDY}
            PARENT_SCOPE
        )
    endfunction()

    find_all_directories_with_clang_tidy(DIRECTORIES_WITH_CLANG_TIDY)

    if(DIRECTORIES_WITH_CLANG_TIDY)
        set_target_properties(bad01 PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND} --directories_with_clang_tidy=${DIRECTORIES_WITH_CLANG_TIDY})
    else()
        set_target_properties(bad01 PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND})
    endif()
endif()
```
I used "*" because (at least on Windows) this character can not be used in a folder name. I have only done limited testing with my hobby projects, there may be other `source_file_extensions` to consider when identifying the source file clang-tidy is being called on.

Thank you for creating such a cool tool. I spent about a day trying to figure out what the issue was and how to fix it but I'm sure this will save me a great deal of time in the future.