### PR TITLE
Ignore errors in samefile

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -94,14 +94,17 @@ class ClangTidyCacheOpts(object):
 
         for command in self._compile_commands_db:
             db_filename = command["file"]
-            if os.path.samefile(filename, db_filename):
-                try:
-                    return shlex.split(command["command"])
-                except KeyError:
+            try:
+                if os.path.samefile(filename, db_filename):
                     try:
-                        return shlex.split(command["arguments"][0])
-                    except:
-                        return "clang-tidy"
+                        return shlex.split(command["command"])
+                    except KeyError:
+                        try:
+                            return shlex.split(command["arguments"][0])
+                        except:
+                            return "clang-tidy"
+            except FileNotFoundError:
+                continue
 
         return []
 


### PR DESCRIPTION
Currently `samefile` is used to check if a file present in the `compile_commands.json` database matches one of the files passed on the command line to `clang-tidy-cache`. However, this causes some issues in the case of generated files, as [samefile](https://docs.python.org/3/library/os.path.html#os.path.samefile) can raise exceptions if one file does not exist. Since our setup is to generate the compile commands database without compiling anything, that database contains references to files that do not exist yet. These files crash clang-tidy-cache.

The fix I'm proposing is simple: if `samefile` throws a `FileNotFoundError`, just consider that the files don't match and continue.