### PR TITLE
Add preprocessor output to hash computation

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -92,6 +92,9 @@ class ClangTidyCacheOpts(object):
                     self._compiler_args[i] = "-"
                 if self._compiler_args[i-1] in ["-c"]:
                     self._compiler_args[i-1] = "-E"
+            for i in range(1, len(self._compiler_args)):
+                if self._compiler_args[i-1] in ["-E"]:
+                    self._compiler_args.insert(i, "-P")
 
     # --------------------------------------------------------------------------
     def _load_compile_command_db(self, filename):
@@ -612,6 +615,20 @@ def hash_inputs(opts):
 
     result = ClangTidyCacheHash(opts)
 
+    # Execute the compiler command defined by the compiler arguments. At this
+    # point if we have compiler arguments with expect that it defines a valid
+    # command to get the preprocess output.
+    # If we have a valid output this gets added to the hash.
+    proc = subprocess.Popen(
+        co_args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+    stdout, stderr = proc.communicate()
+    if stderr:
+        return None
+    result.update(stdout)
+
     #==== Source File Modification Time ===========================================#
 
     source_file_extensions = [".cpp", ".c", ".h", ".hpp", ".cxx"]
@@ -621,15 +638,6 @@ def hash_inputs(opts):
         if os.path.exists(line) and any(line.lower().endswith(ext) for ext in source_file_extensions):
             source_file = os.path.normpath(os.path.realpath(line))
             break
-
-    # Calculate a timestamp-based hash using the modification time of each source file
-    try:
-        mtime = os.path.getmtime(source_file)
-        timestamp_hash = str(int(mtime))
-
-        result.update(timestamp_hash.encode("utf8"))
-    except OSError:
-        return None
 
     #=========== Config Contents ==================================================#
 

--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -100,7 +100,8 @@ class ClangTidyCacheOpts(object):
     def _load_compile_command_db(self, filename):
         try:
             f = open(filename)
-            self._compile_commands_db = json.load(f)
+            self._compile_commands_db = json.loads(f.read().replace("\\",
+                                                                    "\\\\"))
             f.close()
         except Exception:
             return False


### PR DESCRIPTION
This PR adjusts the hash computation such that it include the output of the Clang preprocessor instead of the source file modification file (the latter not being sensitive to changes in included headers).
