### PR TITLE
Update stats when used with data

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -524,9 +524,11 @@ class ClangTidyLocalCache(object):
         path = self._make_path(digest)
         if os.path.isfile(path):
             os.utime(path, None)
+            self.update_stats(True)
             with open(path, "rb") as stream:
                 return stream.read()
         else:
+            self.update_stats(False)
             return None
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
In a recent PR #33 , support for local stats was added. However, those stats are not updated when `CTCACHE_SAVE_OUTPUT` is set, as we don't call `is_cached` but `get_cache_data`. Thus, I added the necessary calls to `update_stats` to update the stats even when used with the data.