### PR TITLE
Add .cc as valid CPP file extension

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -862,7 +862,7 @@ def hash_inputs(opts):
 
     #==== Source File Modification Time ===========================================#
 
-    source_file_extensions = [".cpp", ".c", ".h", ".hpp", ".cxx"]
+    source_file_extensions = [".cpp", ".c", ".cc", ".h", ".hpp", ".cxx"]
 
     # Find the first valid source file in ct_args
     for line in ct_args[1:]:


### PR DESCRIPTION
This add `.cc` as a valid CPP file extension.

Looking at https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html there is some additional extansion that could be added but this fixes this for us and others using Google Code Style guidelines.