### PR TITLE
do not ignore cache data if it is empty

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -890,7 +890,7 @@ class ClangTidyCache(object):
     def get_cache_data(self, digest) -> tp.Optional[bytes]:
         for cache in self._caches:
             data = cache.get_cache_data(digest)
-            if data:
+            if data is not None:
                 return data
 
         return None


### PR DESCRIPTION
Currently, an empty string/entry is ignored by `ClangTidyCache.get_cache_data`, resulting in `None` being returned.
Thus, a cache hit will be ignored and clang-tidy still run if the entry is empty and `save_output` is enabled.
This also contrasts [`run_clang_tidy_cached`](https://github.com/N-Coder/ctcache/blob/a8dbb5c70d15eb513e55ff28c0ac46b13b7a5e9d/clang-tidy-cache#L1092) that correctly checks `if data is not None` instead of only `if data`.