### PR TITLE
Insert the clang_analyzer option before the first -D command line option

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -119,7 +119,8 @@ class ClangTidyCacheOpts(object):
     # --------------------------------------------------------------------------
     def _adjust_compiler_args(self, args):
         if self._compiler_args:
-            self._compiler_args.insert(1, "-D__clang_analyzer__=1")
+            pos = next((pos for pos, arg in enumerate(self._compiler_args) if arg.startswith('-D')), 1)
+            self._compiler_args.insert(pos, "-D__clang_analyzer__=1")
             for i in range(1, len(self._compiler_args)):
                 if self._compiler_args[i-1] in ["-o", "--output"]:
                     self._compiler_args[i] = "-"


### PR DESCRIPTION
I ran into an issue when using ccache.
My compile_commands.json looks like this
"command": "/usr/bin/ccache  clang++ -DBOOST_PROPERTY_TREE_RAPIDXML_STATIC_POOL_SIZE=1024  -D ......"
clang-tidy-cache tries to put -D__clang_analyzer option in position 1 which is before 'clang++' which causes an error, and doesn't carry on with the hash.
It now puts the -D option before the first -D option, or the existing position 1 as the default.

This error was also hidden as stderr isn't logged. The hash function just returns None.  I was going to create a separate PR for that, but could put it in this one if needed.