### PR TITLE
Make local stats update atomic.

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -534,20 +534,24 @@ class ClangTidyLocalStats(object):
     # --------------------------------------------------------------------------
     def read(self):
         with MultiprocessLock(self.stats_file() + ".lock") as _:
-            if os.path.isfile(self.stats_file()):
-                with open(self.stats_file(), 'r') as f:
-                    content = f.read().split()
-                    if len(content) == 2:
-                        return int(content[0]), int(content[1])
-                    else:
-                        self._log.error(f"Invalid stats content in: {self.stats_file()}")
-            return 0,0
+            return self.read_with_lock_held()
+
+    # --------------------------------------------------------------------------
+    def read_with_lock_held(self):
+        if os.path.isfile(self.stats_file()):
+            with open(self.stats_file(), 'r') as f:
+                content = f.read().split()
+                if len(content) == 2:
+                    return int(content[0]), int(content[1])
+                else:
+                    self._log.error(f"Invalid stats content in: {self.stats_file()}")
+        return 0,0
 
     # --------------------------------------------------------------------------
     def update(self, hit):
         try:
-            hits, misses = self.read()
             with MultiprocessLock(self.stats_file() + ".lock") as _:
+                hits, misses = self.read_with_lock_held()
                 if hit:
                     hits += 1
                 else:


### PR DESCRIPTION
The file lock was acquired and release twice, once to read the stats file, and once to write the stats file. As such, writes can get lost.

I was looking at https://github.com/matus-chochlik/ctcache/issues/36 which we hit in our system, so I extracted the locking code into a separate file, launched a 100 parallel copies of the test, and observed that stats file having `74`, `58` etc. as opposed to a guaranteed `100`.

This fix only acquires the file lock once, which could reduce the lock contention that has been observed, and reads, updates, and writes the stats under the lock. This fixes the atomicity of the stats updates as well.