### PR TITLE
Fixing web background and image clipping issues

### DIFF
--- a/clang-tidy-cache-server
+++ b/clang-tidy-cache-server
@@ -566,6 +566,7 @@ class ClangTidyCache(object):
         plt.savefig(
             output,
             transparent=True,
+            bbox_inches="tight",
             format=imgfmt
         )
         fig.clear()
@@ -621,6 +622,7 @@ class ClangTidyCache(object):
         plt.savefig(
             output,
             transparent=True,
+            bbox_inches="tight",
             format=imgfmt
         )
         fig.clear()
@@ -663,6 +665,7 @@ class ClangTidyCache(object):
         plt.savefig(
             output,
             transparent=True,
+            bbox_inches="tight",
             format=imgfmt
         )
         fig.clear()
@@ -705,6 +708,7 @@ class ClangTidyCache(object):
         plt.savefig(
             output,
             transparent=True,
+            bbox_inches="tight",
             format=imgfmt
         )
         fig.clear()

--- a/static/ctcache.css
+++ b/static/ctcache.css
@@ -1,3 +1,8 @@
+.background {
+    background: #0d1117;
+    color: white;
+}
+
 .dashboard {
     font-family: Helvetica;
     display: grid;

--- a/static/index.html
+++ b/static/index.html
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!DOCTYPE html>
-<html>
+<html class="background">
 <head>
 	<meta charset="utf-8"/>
 	<title>clang-tidy-cache-server dashboard</title>


### PR DESCRIPTION
A couple of issues for the ctcache web ui (found and fixes tested on chrome, firefox on mac)
1. The images were created with a dark theme so the labels/axis have a white font. No background colour was set so the background would default to white, and hide the axis etc.  The fix sets the background colour to the same colour as on the example image on github.
2. Some webpage aspect ratios would hide the y axis labels of the grids. Resizing the webpage smaller and with more width than height would resize the images in a way that the y axis labels would be shown again. This changes how the images are saved and the images now show the y label for all webpage height/widths.