### PR TITLE
Avoid repeated recalculation of stats file name

### DIFF
--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -569,7 +569,7 @@ class ClangTidyLocalStats(object):
         if len(content) == 2:
             return int(content[0]), int(content[1])
         else:
-            self._log.error(f"Invalid stats content in: {self.stats_file()}")
+            self._log.error(f"Invalid stats content in: {f.name}")
         return 0,0
 
     # --------------------------------------------------------------------------

--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -556,9 +556,10 @@ class ClangTidyLocalStats(object):
 
     # --------------------------------------------------------------------------
     def read(self):
-        with MultiprocessLock(self.stats_file() + ".lock") as _:
-            if os.path.isfile(self.stats_file()):
-                with open(self.stats_file(), 'r') as f:
+        file = self.stats_file()
+        with MultiprocessLock(file + ".lock") as _:
+            if os.path.isfile(file):
+                with open(file, 'r') as f:
                     return self.read_from_file(f)
             return 0,0
 
@@ -582,16 +583,17 @@ class ClangTidyLocalStats(object):
     # --------------------------------------------------------------------------
     def update(self, hit):
         try:
-            with MultiprocessLock(self.stats_file() + ".lock") as _:
+            file = self.stats_file()
+            with MultiprocessLock(file + ".lock") as _:
                 try:
-                    if os.path.isfile(self.stats_file()):
-                        with open(self.stats_file(), 'r+') as fh:
+                    if os.path.isfile(file):
+                        with open(file, 'r+') as fh:
                             hits, misses = self.read_from_file(fh)
                             fh.seek(0)
                             self.write_to_file(fh, hits, misses, hit)
                             fh.truncate()
                     else:
-                        with open(self.stats_file(), 'w') as fh:
+                        with open(file, 'w') as fh:
                             self.write_to_file(fh, 0, 0, hit)
                 except IOError as e:
                     self._log_error(f"Error writing to file: {e}")

--- a/clang-tidy-cache
+++ b/clang-tidy-cache
@@ -596,7 +596,7 @@ class ClangTidyLocalStats(object):
                         with open(file, 'w') as fh:
                             self.write_to_file(fh, 0, 0, hit)
                 except IOError as e:
-                    self._log_error(f"Error writing to file: {e}")
+                    self._log.error(f"Error writing to file: {e}")
         except Exception as e:
             traceback.print_exc(file=sys.stdout)
             raise


### PR DESCRIPTION
I was looking into https://github.com/matus-chochlik/ctcache/issues/36 again as it showed up in our CI build system recently. This PR has a minor tweak.

The better approach would likely be to move away from the single lock and maybe use the `digest[:2]`-based paths to keep hit/miss stats for each of the 256 buckets. This reduces the contention in the (frequent) update path, at the expense of the (infrequent) `read` and `clear` paths having to enumerate the folders.