### PR TITLE
Introduce option CTCACHE_SAVE_ALL to save clang-tidy's output even in case of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ variables:
 |`CTCACHE_DIR`               |  ✓   |      | the cache storage directory in local mode                |
 |`CTCACHE_EXCLUDE_HASH_REGEX`|  ✓   |      | regular expression of hashes that should not be cached   |
 |`CTCACHE_SAVE_OUTPUT`       |  ✓   |      | saves the stdout output of `clang-tidy` in the cache     |
+|`CTCACHE_SAVE_ALL`          |  ✓   |      | save the output even when `clang-tidy` exited with error |
 |`CTCACHE_LOCAL`             |  ✓   |      | enables the local cache                                  |
 |`CTCACHE_NO_LOCAL_STATS`    |  ✓   |      | disables keeping local cache statistics                  |
 |`CTCACHE_NO_LOCAL_WRITEBACK`|  ✓   |      | disables storage of remote cache hits to the local cache |


### PR DESCRIPTION
In our code base we have a list of generated code files and third party libraries. We don't have control over them meaning that some of them contain warnings. However, we do filter them out using run-clang-tidy.py. This means that clang-tidy itself sometimes runs with exit code != 0 but that's OK. So I would like the ctcache to cope with such situations. 

The approach taken here is to extend the `CTCACHE_SAVE_OUTPUT` option. In the cached output always reserve the first byte for clang-tidy's exit code. The following bytes remain the same. This change by itself doesn't help a lot since the output is anyway just stored if the exit code is ==0. So, the new behavior is introduced by enabling the new `CTCACHE_SAVE_ALL` (or however you might want to call this option) which caches the output even if clang-tidy exited !=0. 

The big problem I see with this change is that backwards compatibility with `CTCACHE_SAVE_OUTPUT` breaks (due to the first introduced byte which is not present in an existing cache). Naturally this could be limited by only adding the exit code as the first byte when `CTCACHE_SAVE_ALL` is enabled. 