### PR TITLE
Constrain commands to the Redis server to the bare minimum: AUTH, GET, SET

### DIFF
--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -742,6 +742,13 @@ class ClangTidyRedisCache(object):
             port=opts.redis_port(),
             username=opts.redis_username(),
             password=opts.redis_password(),
+
+            # the two settings below are used to avoid sending any commands to the Redis
+            # server other than AUTH, GET, and SET (to let the ctcache operate with a
+            # server configuration giving only minimal permissions to the given user)
+            lib_name=None,
+            lib_version=None
+
         )
         self._namespace = opts.redis_namespace()
 


### PR DESCRIPTION
In the server configuration we use, the Redis user used to read and write the ctcache stuff has only minimal permissions. By default redis-py always sends some `CLIENT SETINFO ...` commands to the server. In our case this results in errors. I think these commands can be avoid in case of ctcache. 

Of course, this could be made configurable, but I guess it's favorable to not overwhelm the user by configuration options. Therefore, I think this would make a good default.