### PR TITLE
Fix the 'clang-tidy' wrapper script

### DIFF
--- a/clang-tidy
+++ b/clang-tidy
@@ -21,7 +21,9 @@ done
 
 CTCACHE_CLANG_TIDY="${CTCACHE_CLANG_TIDY:-/usr/bin/clang-tidy}"
 
+python="/usr/bin/env python3"
+
 if [[ ${CTCACHE_DISABLE:-0} -ne 0 ]]
 then "${CTCACHE_CLANG_TIDY}" "${CTCACHE_CLANG_TIDY_OPTS[@]}" "${@}"
-else "$(dirname $(realpath ${0}))/src/ctcache/clang_tidy_cache.py" "${CTCACHE_CLANG_TIDY}" "${CTCACHE_CLANG_TIDY_OPTS[@]}" "${@}"
+else $python "$(dirname $(realpath ${0}))/src/ctcache/clang_tidy_cache.py" "${CTCACHE_CLANG_TIDY}" "${CTCACHE_CLANG_TIDY_OPTS[@]}" "${@}"
 fi


### PR DESCRIPTION
In 05f3db7c716eba8cbbdbba880fc1aedb84a67654 (move to src-layout), the file permission of `clang-tidy-cache.py` is 644; before that the `clang-tidy-cache` script had 755. This caused the `clang-tidy` script to fail when invoking `clang-tidy-cache.py`.

Run the script via `/usr/bin/env python3` (equivalent to the shbang in `clang-tidy-cache.py`) to fix this.

(Another way to fix this would be to restore the 755 permissions on `clang-tidy-cache.py` (not the usual practice for source files in a Python package). Or `clang-tidy` could call the pip-installed `clang-tidy-cache` script (but that would require installing on `PATH`).)