### PR TITLE
Always include the Clang-Tidy config in the hash

### DIFF
--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -1151,14 +1151,6 @@ def source_file_changed(cpp_line):
             return os.path.realpath(os.path.dirname(found_path))
 
 # ------------------------------------------------------------------------------
-def find_ct_config(search_path):
-    while search_path and search_path != "/":
-        search_path = os.path.dirname(search_path)
-        ct_config = os.path.join(search_path, '.clang-tidy')
-        if os.path.isfile(ct_config):
-            return ct_config
-
-# ------------------------------------------------------------------------------
 def hash_inputs(log, opts):
     ct_args = opts.clang_tidy_args()
     co_args = opts.compiler_args()

--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -1159,7 +1159,7 @@ def hash_inputs(log, opts):
         return None
 
     def _is_src_ext(s):
-        exts = [".cppm", ".cpp", ".c", ".cc", ".h", ".hpp", ".cxx"] 
+        exts = [".cppm", ".cpp", ".c", ".cc", ".h", ".hpp", ".cxx"]
         return any(s.lower().endswith(ext) for ext in exts)
 
     result = ClangTidyCacheHash(opts)

--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -89,13 +89,13 @@ class ClangTidyCacheOpts(object):
     # --------------------------------------------------------------------------
     def running_on_msvc(self):
         if self._compiler_args:
-           return os.path.basename(self._compiler_args[0]) == "cl.exe"
+            return os.path.basename(self._compiler_args[0]) == "cl.exe"
         return False
 
     # --------------------------------------------------------------------------
     def running_on_clang_cl(self):
         if self._compiler_args:
-           return os.path.basename(self._compiler_args[0]) == "clang-cl.exe"
+            return os.path.basename(self._compiler_args[0]) == "clang-cl.exe"
         return False
 
     # --------------------------------------------------------------------------

--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -45,23 +45,6 @@ class ClangTidyCacheOpts(object):
     # --------------------------------------------------------------------------
     def __init__(self, log, args):
         self._log = log
-        self._directories_with_clang_tidy = []
-
-        # Define the prefix used to identify directories with clang-tidy
-        prefix = '--directories_with_clang_tidy='
-
-        # Iterate through the command line arguments
-        for index, arg in enumerate(args):
-            if arg.startswith(prefix):
-                # Split the argument using '*' as a separator to get a list
-                # of directories, I used '*' because a folder cannot contain
-                # this character in its name whereas it can contain `,`
-                self._directories_with_clang_tidy = arg[len(prefix):].split('*')
-
-                # Remove the argument because clang-tidy will not like it
-                args.pop(index)
-
-                break
 
         if len(args) < 1:
             self._log.error("Missing arguments")
@@ -221,10 +204,6 @@ class ClangTidyCacheOpts(object):
             return self._original_args[0] == "--zero-stats"
         except IndexError:
             return False
-
-    # --------------------------------------------------------------------------
-    def directories_with_clang_tidy(self):
-        return self._directories_with_clang_tidy
 
     # --------------------------------------------------------------------------
     def original_args(self):
@@ -1201,29 +1180,31 @@ def hash_inputs(log, opts):
 
         result.update(stdout)
 
+    # --- Config Contents ------------------------------------------------------
+    # (as obtained by running clang-tidy with --dump-config flag)
+
+    ct_args_flags = [ ct_args[0] ]
+    source_files = []
+
     for arg in ct_args[1:]:
         if os.path.exists(arg) and _is_src_ext(arg):
-            source_file = os.path.normpath(os.path.realpath(arg))
-            break
+            source_files.append(os.path.normpath(os.path.realpath(arg)))
+        else:
+            ct_args_flags.append(arg)
 
-    # --- Config Contents ------------------------------------------------------
-
-    config_directories = opts.directories_with_clang_tidy()
-    
-    ct_config_paths = set()
-
-    for directory in config_directories:
-        directory = os.path.normpath(directory.strip())
-        common_path = os.path.commonpath([source_file, directory])
-
-        if common_path == directory:
-            ct_config_paths.add(os.path.join(directory, '.clang-tidy'))
-
-    for ct_config in sorted(ct_config_paths):
-        with open(ct_config, "rt") as ct_config:
-            for line in ct_config:
-                chunk = opts.adjust_chunk(line)
-                result.update(chunk)
+    for source_file in sorted(source_files):
+        ct_dump_cfg_source_file = ct_args_flags + [ "--dump-config",  source_file ]
+        proc = subprocess.Popen(
+            ct_dump_cfg_source_file,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+        stdout, stderr = proc.communicate()
+        if (proc.returncode == 0) and (len(stdout) > 0):
+            result.update(stdout)
+        else:
+            msg = f"Failed dumping the clang-tidy config with <{' '.join(ct_dump_cfg_source_file)}>"
+            raise RuntimeError(msg)
 
     # --- Clang-Tidy and Compiler Args -----------------------------------------
 


### PR DESCRIPTION
After thinking about the tool a bit, I concluded that the Clang-Tidy configuration also needs to be included in the hash. The (not so much documented) option `--directories_with_clang_tidy=...` could help there. However, I think that's not as handy as I want it to be. I think this has to be done by default. Furthermore, this flag could include configuration files which are even not of relevance for the processed file. 

Therefore, I was hunting a more generic solution. My proposal here uses the Clang-Tidy tool itself. I'm asking it to dump the configuration for the file to be processed. In this way I don't have to scan for `.clang-tidy` files, but let Clang-Tidy handle that. This would even work if the user uses Clang-Tidy command line option `--config-file`. 

Of course, the drawback of this solution is that it takes some time to execute Clang-Tidy to dump the config. Yet, it's unclear to me if that's much slower than reading and hashing all the `.clang-tidy` files. So if desired, we could add this as option.