### PR TITLE
Replace == with is; remove duplicate import

### DIFF
--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -16,7 +16,6 @@ import tempfile
 import subprocess
 import json
 import shlex
-import sys
 import time
 import traceback
 import typing as tp
@@ -148,7 +147,7 @@ class ClangTidyCacheOpts(object):
 
     # --------------------------------------------------------------------------
     def _compiler_args_for(self, filename):
-        if self._compile_commands_db == None:
+        if self._compile_commands_db is None:
             return []
 
         filename = os.path.expanduser(filename)
@@ -437,9 +436,9 @@ class ClangTidyServerCache(object):
         try:
             query = self._requests.get(self._make_query_url(digest), timeout=3)
             if query.status_code == 200:
-                if query.json() == True:
+                if query.json() is True:
                     return True
-                elif query.json() == False:
+                elif query.json() is False:
                     return False
                 else:
                     self._log.error("is_cached: Can't connect to server {0}, error {1}".format(


### PR DESCRIPTION
Fix the usage of `==` instead of `is`, `is` is more correct and Pythonic, and more consistent with the project as it is used in the other file for comparison against [None](https://github.com/matus-chochlik/ctcache/blob/0c0de7d63eff775d9bbcf10f69cab5d9e2c43f4c/src/ctcache/clang_tidy_cache_server.py#L386).
remove duplicate import for the `sys` module.