### PR TITLE
Add support to retain comments in hash input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ variables:
 |`CTCACHE_EXCLUDE_HASH_REGEX`|  ✓   |      | regular expression of hashes that should not be cached   |
 |`CTCACHE_SAVE_OUTPUT`       |  ✓   |      | saves the stdout output of `clang-tidy` in the cache     |
 |`CTCACHE_SAVE_ALL`          |  ✓   |      | save the output even when `clang-tidy` exited with error |
+|`CTCACHE_KEEP_COMMENTS`     |  ✓   |      | include source comments (e.g. `NOLINT`) in the hash      |
 |`CTCACHE_LOCAL`             |  ✓   |      | enables the local cache                                  |
 |`CTCACHE_NO_LOCAL_STATS`    |  ✓   |      | disables keeping local cache statistics                  |
 |`CTCACHE_NO_LOCAL_WRITEBACK`|  ✓   |      | disables storage of remote cache hits to the local cache |

--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -134,6 +134,8 @@ class ClangTidyCacheOpts(object):
                         self._compiler_args[i-1] = "-EP"
                     else:
                         self._compiler_args.insert(i, "-P")
+                    if self.keep_comments():
+                        self._compiler_args.insert(i, "-C")
 
     # --------------------------------------------------------------------------
     def _load_compile_command_db(self, filename):
@@ -354,6 +356,10 @@ class ClangTidyCacheOpts(object):
     # --------------------------------------------------------------------------
     def strip_src(self):
         return getenv_boolean_flag("CTCACHE_STRIP_SRC")
+
+    # --------------------------------------------------------------------------
+    def keep_comments(self):
+        return getenv_boolean_flag("CTCACHE_KEEP_COMMENTS")
 
     # --------------------------------------------------------------------------
     def exclude_hash_regex(self):


### PR DESCRIPTION
Implements the feature described in https://github.com/matus-chochlik/ctcache/issues/66.

With this change, and the opt-in flag of `CTCACHE_KEEP_COMMENTS`, I was able to tweak `// NOLINT` suppressions and trigger cache invalidation. The only drawback is the much bigger input to the hash function (in our case I saw up to 33% increase in the input with comments retained). Ideally, we'd be able to strip any comments that don't contain `.*NOLINT.*` but that'd require another pass over pre-processor output with matching comment lexing logic which could be bug-ridden.