### PR TITLE
Add redis socket timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,43 +109,45 @@ docker run -p "80:5000" -v "ctcache:/var/lib/ctcache" -it --rm --name ctcache ct
 The client and server can be configured by setting the following environment
 variables:
 
-|       variable             |client|server|                description                               |
-|----------------------------|:----:|:----:|----------------------------------------------------------|
-|`CTCACHE_CLANG_TIDY`        |  ✓   |      | path to the `clang-tidy` executable                      |
-|`CTCACHE_DISABLE`           |  ✓   |      | disables cache, always runs `clang-tidy`                 |
-|`CTCACHE_SKIP`              |  ✓   |      | disables analysis altogether, returns OK                 |
-|`CTCACHE_STRIP`             |  ✓   |      | list of strings stripped from inputs                     |
-|`CTCACHE_STRIP_SRC`         |  ✓   |      | If set to true, apply strip paths to source code as well |
-|`CTCACHE_DUMP`              |  ✓   |      | dumps all hash inputs into a file                        |
-|`CTCACHE_DUMP_DIR`          |  ✓   |      | the directory to dump diagnostic info                    |
-|`CTCACHE_DEBUG`             |  ✓   |      | enables debugging output                                 |
-|`CTCACHE_DIR`               |  ✓   |      | the cache storage directory in local mode                |
-|`CTCACHE_EXCLUDE_HASH_REGEX`|  ✓   |      | regular expression of hashes that should not be cached   |
-|`CTCACHE_SAVE_OUTPUT`       |  ✓   |      | saves the stdout output of `clang-tidy` in the cache     |
-|`CTCACHE_SAVE_ALL`          |  ✓   |      | save the output even when `clang-tidy` exited with error |
-|`CTCACHE_KEEP_COMMENTS`     |  ✓   |      | include source comments (e.g. `NOLINT`) in the hash      |
-|`CTCACHE_LOCAL`             |  ✓   |      | enables the local cache                                  |
-|`CTCACHE_NO_LOCAL_STATS`    |  ✓   |      | disables keeping local cache statistics                  |
-|`CTCACHE_NO_LOCAL_WRITEBACK`|  ✓   |      | disables storage of remote cache hits to the local cache |
-|`CTCACHE_S3_BUCKET`         |  ✓   |      | the S3 bucket to store cache remotely                    |
-|`CTCACHE_S3_FOLDER`         |  ✓   |      | the prefix directory in S3, w/o leading and trailing `/` |
-|`CTCACHE_S3_NO_CREDENTIALS` |  ✓   |      | if set, script won't try to put objects to S3            |
-|`CTCACHE_S3_READ_ONLY`      |  ✓   |      | if set, script won't try to put objects to S3            |
-|`CTCACHE_PROTO`             |  ✓   |      | protocol for connecting to the server                    |
-|`CTCACHE_HOST`              |  ✓   |  ✓   | hostname or IP address of the server                     |
-|`CTCACHE_HOST_READ_ONLY`    |  ✓   |      | if set, script won't try to push objects to server       |
-|`CTCACHE_PORT`              |  ✓   |  ✓   | listening port of the server                             |
-|`CTCACHE_WEBROOT`           |      |  ✓   | directory containing static server files                 |
-|`CTCACHE_GCS_BUCKET`        |  ✓   |      | the Google Cloud Storage bucket to store cache remotely  |
-|`CTCACHE_GCS_FOLDER`        |  ✓   |      | the prefix in GCS, w/o leading and trailing `/`          |
-|`CTCACHE_GCS_NO_CREDENTIALS`|  ✓   |      | if set, script won't try to put objects to GCS           |
-|`CTCACHE_GCS_READ_ONLY`     |  ✓   |      | if set, script won't try to put objects to GCS           |
-|`CTCACHE_REDIS_HOST`        |  ✓   |      | hostname or IP address of Redis server                   |
-|`CTCACHE_REDIS_PORT`        |  ✓   |      | port of the Redis server (default 6379)                  |
-|`CTCACHE_REDIS_USERNAME`    |  ✓   |      | user name to connect to the Redis server                 |
-|`CTCACHE_REDIS_PASSWORD`    |  ✓   |      | password to connect to the Redis server                  |
-|`CTCACHE_REDIS_NAMESPACE`   |  ✓   |      | namespace to store objects in Redis (default `/ctcache`) |
-|`CTCACHE_REDIS_READ_ONLY`   |  ✓   |      | if set, script won't try to put objects to Redis         |
+| variable                         |client|server| description                                                      |
+|----------------------------------|:----:|:----:|------------------------------------------------------------------|
+| `CTCACHE_CLANG_TIDY`             |  ✓   |      | path to the `clang-tidy` executable                              |
+| `CTCACHE_DISABLE`                |  ✓   |      | disables cache, always runs `clang-tidy`                         |
+| `CTCACHE_SKIP`                   |  ✓   |      | disables analysis altogether, returns OK                         |
+| `CTCACHE_STRIP`                  |  ✓   |      | list of strings stripped from inputs                             |
+| `CTCACHE_STRIP_SRC`              |  ✓   |      | If set to true, apply strip paths to source code as well         |
+| `CTCACHE_DUMP`                   |  ✓   |      | dumps all hash inputs into a file                                |
+| `CTCACHE_DUMP_DIR`               |  ✓   |      | the directory to dump diagnostic info                            |
+| `CTCACHE_DEBUG`                  |  ✓   |      | enables debugging output                                         |
+| `CTCACHE_DIR`                    |  ✓   |      | the cache storage directory in local mode                        |
+| `CTCACHE_EXCLUDE_HASH_REGEX`     |  ✓   |      | regular expression of hashes that should not be cached           |
+| `CTCACHE_SAVE_OUTPUT`            |  ✓   |      | saves the stdout output of `clang-tidy` in the cache             |
+| `CTCACHE_SAVE_ALL`               |  ✓   |      | save the output even when `clang-tidy` exited with error         |
+| `CTCACHE_KEEP_COMMENTS`          |  ✓   |      | include source comments (e.g. `NOLINT`) in the hash              |
+| `CTCACHE_LOCAL`                  |  ✓   |      | enables the local cache                                          |
+| `CTCACHE_NO_LOCAL_STATS`         |  ✓   |      | disables keeping local cache statistics                          |
+| `CTCACHE_NO_LOCAL_WRITEBACK`     |  ✓   |      | disables storage of remote cache hits to the local cache         |
+| `CTCACHE_S3_BUCKET`              |  ✓   |      | the S3 bucket to store cache remotely                            |
+| `CTCACHE_S3_FOLDER`              |  ✓   |      | the prefix directory in S3, w/o leading and trailing `/`         |
+| `CTCACHE_S3_NO_CREDENTIALS`      |  ✓   |      | if set, script won't try to put objects to S3                    |
+| `CTCACHE_S3_READ_ONLY`           |  ✓   |      | if set, script won't try to put objects to S3                    |
+| `CTCACHE_PROTO`                  |  ✓   |      | protocol for connecting to the server                            |
+| `CTCACHE_HOST`                   |  ✓   |  ✓   | hostname or IP address of the server                             |
+| `CTCACHE_HOST_READ_ONLY`         |  ✓   |      | if set, script won't try to push objects to server               |
+| `CTCACHE_PORT`                   |  ✓   |  ✓   | listening port of the server                                     |
+| `CTCACHE_WEBROOT`                |      |  ✓   | directory containing static server files                         |
+| `CTCACHE_GCS_BUCKET`             |  ✓   |      | the Google Cloud Storage bucket to store cache remotely          |
+| `CTCACHE_GCS_FOLDER`             |  ✓   |      | the prefix in GCS, w/o leading and trailing `/`                  |
+| `CTCACHE_GCS_NO_CREDENTIALS`     |  ✓   |      | if set, script won't try to put objects to GCS                   |
+| `CTCACHE_GCS_READ_ONLY`          |  ✓   |      | if set, script won't try to put objects to GCS                   |
+| `CTCACHE_REDIS_HOST`             |  ✓   |      | hostname or IP address of Redis server                           |
+| `CTCACHE_REDIS_PORT`             |  ✓   |      | port of the Redis server (default 6379)                          |
+| `CTCACHE_REDIS_USERNAME`         |  ✓   |      | user name to connect to the Redis server                         |
+| `CTCACHE_REDIS_PASSWORD`         |  ✓   |      | password to connect to the Redis server                          |
+| `CTCACHE_REDIS_NAMESPACE`        |  ✓   |      | namespace to store objects in Redis (default `/ctcache`)         |
+| `CTCACHE_REDIS_READ_ONLY`        |  ✓   |      | if set, script won't try to put objects to Redis                 |
+| `CTCACHE_SOCKET_CONNECT_TIMEOUT` |  ✓   |      | Socket connect timeout, seconds, parsed as float (default `0.1`) |
+| `CTCACHE_SOCKET_TIMEOUT`         |  ✓   |      | Socket timeout, seconds, parsed as float (default `10.0`)        |
 
 
 ### The dashboard

--- a/README.md
+++ b/README.md
@@ -109,45 +109,45 @@ docker run -p "80:5000" -v "ctcache:/var/lib/ctcache" -it --rm --name ctcache ct
 The client and server can be configured by setting the following environment
 variables:
 
-| variable                         |client|server| description                                                      |
-|----------------------------------|:----:|:----:|------------------------------------------------------------------|
-| `CTCACHE_CLANG_TIDY`             |  ✓   |      | path to the `clang-tidy` executable                              |
-| `CTCACHE_DISABLE`                |  ✓   |      | disables cache, always runs `clang-tidy`                         |
-| `CTCACHE_SKIP`                   |  ✓   |      | disables analysis altogether, returns OK                         |
-| `CTCACHE_STRIP`                  |  ✓   |      | list of strings stripped from inputs                             |
-| `CTCACHE_STRIP_SRC`              |  ✓   |      | If set to true, apply strip paths to source code as well         |
-| `CTCACHE_DUMP`                   |  ✓   |      | dumps all hash inputs into a file                                |
-| `CTCACHE_DUMP_DIR`               |  ✓   |      | the directory to dump diagnostic info                            |
-| `CTCACHE_DEBUG`                  |  ✓   |      | enables debugging output                                         |
-| `CTCACHE_DIR`                    |  ✓   |      | the cache storage directory in local mode                        |
-| `CTCACHE_EXCLUDE_HASH_REGEX`     |  ✓   |      | regular expression of hashes that should not be cached           |
-| `CTCACHE_SAVE_OUTPUT`            |  ✓   |      | saves the stdout output of `clang-tidy` in the cache             |
-| `CTCACHE_SAVE_ALL`               |  ✓   |      | save the output even when `clang-tidy` exited with error         |
-| `CTCACHE_KEEP_COMMENTS`          |  ✓   |      | include source comments (e.g. `NOLINT`) in the hash              |
-| `CTCACHE_LOCAL`                  |  ✓   |      | enables the local cache                                          |
-| `CTCACHE_NO_LOCAL_STATS`         |  ✓   |      | disables keeping local cache statistics                          |
-| `CTCACHE_NO_LOCAL_WRITEBACK`     |  ✓   |      | disables storage of remote cache hits to the local cache         |
-| `CTCACHE_S3_BUCKET`              |  ✓   |      | the S3 bucket to store cache remotely                            |
-| `CTCACHE_S3_FOLDER`              |  ✓   |      | the prefix directory in S3, w/o leading and trailing `/`         |
-| `CTCACHE_S3_NO_CREDENTIALS`      |  ✓   |      | if set, script won't try to put objects to S3                    |
-| `CTCACHE_S3_READ_ONLY`           |  ✓   |      | if set, script won't try to put objects to S3                    |
-| `CTCACHE_PROTO`                  |  ✓   |      | protocol for connecting to the server                            |
-| `CTCACHE_HOST`                   |  ✓   |  ✓   | hostname or IP address of the server                             |
-| `CTCACHE_HOST_READ_ONLY`         |  ✓   |      | if set, script won't try to push objects to server               |
-| `CTCACHE_PORT`                   |  ✓   |  ✓   | listening port of the server                                     |
-| `CTCACHE_WEBROOT`                |      |  ✓   | directory containing static server files                         |
-| `CTCACHE_GCS_BUCKET`             |  ✓   |      | the Google Cloud Storage bucket to store cache remotely          |
-| `CTCACHE_GCS_FOLDER`             |  ✓   |      | the prefix in GCS, w/o leading and trailing `/`                  |
-| `CTCACHE_GCS_NO_CREDENTIALS`     |  ✓   |      | if set, script won't try to put objects to GCS                   |
-| `CTCACHE_GCS_READ_ONLY`          |  ✓   |      | if set, script won't try to put objects to GCS                   |
-| `CTCACHE_REDIS_HOST`             |  ✓   |      | hostname or IP address of Redis server                           |
-| `CTCACHE_REDIS_PORT`             |  ✓   |      | port of the Redis server (default 6379)                          |
-| `CTCACHE_REDIS_USERNAME`         |  ✓   |      | user name to connect to the Redis server                         |
-| `CTCACHE_REDIS_PASSWORD`         |  ✓   |      | password to connect to the Redis server                          |
-| `CTCACHE_REDIS_NAMESPACE`        |  ✓   |      | namespace to store objects in Redis (default `/ctcache`)         |
-| `CTCACHE_REDIS_READ_ONLY`        |  ✓   |      | if set, script won't try to put objects to Redis                 |
-| `CTCACHE_SOCKET_CONNECT_TIMEOUT` |  ✓   |      | Socket connect timeout, seconds, parsed as float (default `0.1`) |
-| `CTCACHE_SOCKET_TIMEOUT`         |  ✓   |      | Socket timeout, seconds, parsed as float (default `10.0`)        |
+| variable                          |client|server| description                                                      |
+|-----------------------------------|:----:|:----:|------------------------------------------------------------------|
+| `CTCACHE_CLANG_TIDY`              |  ✓   |      | path to the `clang-tidy` executable                              |
+| `CTCACHE_DISABLE`                 |  ✓   |      | disables cache, always runs `clang-tidy`                         |
+| `CTCACHE_SKIP`                    |  ✓   |      | disables analysis altogether, returns OK                         |
+| `CTCACHE_STRIP`                   |  ✓   |      | list of strings stripped from inputs                             |
+| `CTCACHE_STRIP_SRC`               |  ✓   |      | If set to true, apply strip paths to source code as well         |
+| `CTCACHE_DUMP`                    |  ✓   |      | dumps all hash inputs into a file                                |
+| `CTCACHE_DUMP_DIR`                |  ✓   |      | the directory to dump diagnostic info                            |
+| `CTCACHE_DEBUG`                   |  ✓   |      | enables debugging output                                         |
+| `CTCACHE_DIR`                     |  ✓   |      | the cache storage directory in local mode                        |
+| `CTCACHE_EXCLUDE_HASH_REGEX`      |  ✓   |      | regular expression of hashes that should not be cached           |
+| `CTCACHE_SAVE_OUTPUT`             |  ✓   |      | saves the stdout output of `clang-tidy` in the cache             |
+| `CTCACHE_SAVE_ALL`                |  ✓   |      | save the output even when `clang-tidy` exited with error         |
+| `CTCACHE_KEEP_COMMENTS`           |  ✓   |      | include source comments (e.g. `NOLINT`) in the hash              |
+| `CTCACHE_LOCAL`                   |  ✓   |      | enables the local cache                                          |
+| `CTCACHE_NO_LOCAL_STATS`          |  ✓   |      | disables keeping local cache statistics                          |
+| `CTCACHE_NO_LOCAL_WRITEBACK`      |  ✓   |      | disables storage of remote cache hits to the local cache         |
+| `CTCACHE_S3_BUCKET`               |  ✓   |      | the S3 bucket to store cache remotely                            |
+| `CTCACHE_S3_FOLDER`               |  ✓   |      | the prefix directory in S3, w/o leading and trailing `/`         |
+| `CTCACHE_S3_NO_CREDENTIALS`       |  ✓   |      | if set, script won't try to put objects to S3                    |
+| `CTCACHE_S3_READ_ONLY`            |  ✓   |      | if set, script won't try to put objects to S3                    |
+| `CTCACHE_PROTO`                   |  ✓   |      | protocol for connecting to the server                            |
+| `CTCACHE_HOST`                    |  ✓   |  ✓   | hostname or IP address of the server                             |
+| `CTCACHE_HOST_READ_ONLY`          |  ✓   |      | if set, script won't try to push objects to server               |
+| `CTCACHE_PORT`                    |  ✓   |  ✓   | listening port of the server                                     |
+| `CTCACHE_WEBROOT`                 |      |  ✓   | directory containing static server files                         |
+| `CTCACHE_GCS_BUCKET`              |  ✓   |      | the Google Cloud Storage bucket to store cache remotely          |
+| `CTCACHE_GCS_FOLDER`              |  ✓   |      | the prefix in GCS, w/o leading and trailing `/`                  |
+| `CTCACHE_GCS_NO_CREDENTIALS`      |  ✓   |      | if set, script won't try to put objects to GCS                   |
+| `CTCACHE_GCS_READ_ONLY`           |  ✓   |      | if set, script won't try to put objects to GCS                   |
+| `CTCACHE_REDIS_HOST`              |  ✓   |      | hostname or IP address of Redis server                           |
+| `CTCACHE_REDIS_PORT`              |  ✓   |      | port of the Redis server (default 6379)                          |
+| `CTCACHE_REDIS_USERNAME`          |  ✓   |      | user name to connect to the Redis server                         |
+| `CTCACHE_REDIS_PASSWORD`          |  ✓   |      | password to connect to the Redis server                          |
+| `CTCACHE_REDIS_NAMESPACE`         |  ✓   |      | namespace to store objects in Redis (default `/ctcache`)         |
+| `CTCACHE_REDIS_READ_ONLY`         |  ✓   |      | if set, script won't try to put objects to Redis                 |
+| `CTCACHE_REDIS_CONNECT_TIMEOUT`   |  ✓   |      | Socket connect timeout, seconds, parsed as float (default `0.1`) |
+| `CTCACHE_REDIS_OPERATION_TIMEOUT` |  ✓   |      | Socket timeout, seconds, parsed as float (default `10.0`)        |
 
 
 ### The dashboard

--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -391,6 +391,14 @@ class ClangTidyCacheOpts(object):
         return os.getenv("CTCACHE_REDIS_PASSWORD", "")
 
     # --------------------------------------------------------------------------
+    def redis_connect_timeout(self) -> float:
+        return float(os.getenv("CTCACHE_REDIS_CONNECT_TIMEOUT", "0.1"))
+
+    # --------------------------------------------------------------------------
+    def redis_socket_timeout(self) -> float:
+        return float(os.getenv("CTCACHE_REDIS_OPERATION_TIMEOUT", "10.0"))
+
+    # --------------------------------------------------------------------------
     def redis_namespace(self) -> str:
         return os.getenv("CTCACHE_REDIS_NAMESPACE", "ctcache/")
 
@@ -726,6 +734,8 @@ class ClangTidyRedisCache(object):
             port=opts.redis_port(),
             username=opts.redis_username(),
             password=opts.redis_password(),
+            socket_connect_timeout=opts.redis_connect_timeout(),
+            socket_timeout=opts.redis_socket_timeout(),
             # the two settings below are used to avoid sending any commands to the Redis
             # server other than AUTH, GET, and SET (to let the ctcache operate with a
             # server configuration giving only minimal permissions to the given user)


### PR DESCRIPTION
Fixes #75 

This adds timeouts to redis remote backend

I used the same [defaults timeouts as ccache](https://ccache.dev/manual/4.10.2.html#_redis_storage_backend)

Perhaps we could have a slightly longer connect timeout default.