### PR TITLE
Additional redis settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ variables:
 | `CTCACHE_GCS_READ_ONLY`           |  ✓   |      | if set, script won't try to put objects to GCS                   |
 | `CTCACHE_REDIS_HOST`              |  ✓   |      | hostname or IP address of Redis server                           |
 | `CTCACHE_REDIS_PORT`              |  ✓   |      | port of the Redis server (default 6379)                          |
+| `CTCACHE_REDIS_DB`                |  ✓   |      | database id in Redis server (default 0)                          |
 | `CTCACHE_REDIS_USERNAME`          |  ✓   |      | user name to connect to the Redis server                         |
 | `CTCACHE_REDIS_PASSWORD`          |  ✓   |      | password to connect to the Redis server                          |
 | `CTCACHE_REDIS_NAMESPACE`         |  ✓   |      | namespace to store objects in Redis (default `/ctcache`)         |

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ variables:
 | `CTCACHE_REDIS_READ_ONLY`         |  ✓   |      | if set, script won't try to put objects to Redis                 |
 | `CTCACHE_REDIS_CONNECT_TIMEOUT`   |  ✓   |      | Socket connect timeout, seconds, parsed as float (default `0.1`) |
 | `CTCACHE_REDIS_OPERATION_TIMEOUT` |  ✓   |      | Socket timeout, seconds, parsed as float (default `10.0`)        |
+| `CTCACHE_REDIS_CACHE_TTL`         |  ✓   |      | cache TTL in seconds, parsed as int (default `-1`)               |
 
 
 ### The dashboard

--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -392,6 +392,10 @@ class ClangTidyCacheOpts(object):
         return int(os.getenv("CTCACHE_REDIS_PORT", "6379"))
 
     # --------------------------------------------------------------------------
+    def redis_db(self) -> int:
+        return int(os.getenv("CTCACHE_REDIS_DB", "0"))
+
+    # --------------------------------------------------------------------------
     def redis_username(self) -> str:
         return os.getenv("CTCACHE_REDIS_USERNAME", "")
 
@@ -748,6 +752,7 @@ class ClangTidyRedisCache(object):
         self._cli = redis.Redis(
             host=opts.redis_host(),
             port=opts.redis_port(),
+            db=opts.redis_db(),
             username=opts.redis_username(),
             password=opts.redis_password(),
             socket_connect_timeout=opts.redis_connect_timeout(),


### PR DESCRIPTION
This adds two options which are potentially useful for a redis cache deployment.

* specify redis db other than 0
* set a TTL on cache entries, also refreshed on reads