### PR TITLE
fix 'JSONDecodeError' is not defined.

### DIFF
--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -146,7 +146,7 @@ class ClangTidyCacheOpts(object):
                 try:
                     js = cdb.replace(r'\\\"', "'").replace("\\", "\\\\")
                     self._compile_commands_db = json.loads(js)
-                except JSONDecodeError:
+                except json.JSONDecodeError:
                     self._compile_commands_db = json.loads(cdb)
 
         except Exception as err:


### PR DESCRIPTION
Runtime Error:
Loading compile command DB failed: NameError("name 'JSONDecodeError' is not defined")