### PR TITLE
Add CTCACHE_LOG_LEVEL to allow more verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cache for `clang-tidy` static analysis results
 
-## Introduction 
+## Introduction
 
 `clang-tidy-cache` is a command-line application which "wraps" invocations
 of the `clang-tidy` static analysis tool and caches the results of successful
@@ -125,6 +125,7 @@ variables:
 | `CTCACHE_SAVE_ALL`                |  ✓   |      | save the output even when `clang-tidy` exited with error         |
 | `CTCACHE_KEEP_COMMENTS`           |  ✓   |      | include source comments (e.g. `NOLINT`) in the hash              |
 | `CTCACHE_LOCAL`                   |  ✓   |      | enables the local cache                                          |
+| `CTCACHE_LOG_LEVEL`               |  ✓   |      | set the log level: (critical, error, warning, info, debug)       |
 | `CTCACHE_NO_LOCAL_STATS`          |  ✓   |      | disables keeping local cache statistics                          |
 | `CTCACHE_NO_LOCAL_WRITEBACK`      |  ✓   |      | disables storage of remote cache hits to the local cache         |
 | `CTCACHE_S3_BUCKET`               |  ✓   |      | the S3 bucket to store cache remotely                            |


### PR DESCRIPTION
This adds `CTCACHE_LOG_LEVEL` to allow setting it to a different level than `WARNING` (the default) to enable more verbose logging.

I've also added a couple of debug traces that we find useful.

To give you some context, we want to debug for which files `clang-tidy-cache` is reusing the cache and for which ones it's not. Since CMake doesn't provide a way to (as far as I know) to get the output of the clang-tidy call, I ended up creating yet another wrapper for `clang-tidy-cache` that appends to a temp file the output after setting `CTCACHE_LOG_LEVEL=debug`: https://github.com/ClickHouse/ClickHouse/pull/83153