### PR TITLE
add simple authentication mechanism for writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ variables:
 
 | variable                          |client|server| description                                                      |
 |-----------------------------------|:----:|:----:|------------------------------------------------------------------|
+| `CTCACHE_AUTH_KEY`                |  ✓   |      | this key is passed to ctcache server when modifying cache        |
 | `CTCACHE_CLANG_TIDY`              |  ✓   |      | path to the `clang-tidy` executable                              |
 | `CTCACHE_DISABLE`                 |  ✓   |      | disables cache, always runs `clang-tidy`                         |
 | `CTCACHE_SKIP`                    |  ✓   |      | disables analysis altogether, returns OK                         |
@@ -134,7 +135,7 @@ variables:
 | `CTCACHE_PROTO`                   |  ✓   |      | protocol for connecting to the server                            |
 | `CTCACHE_HOST`                    |  ✓   |  ✓   | hostname or IP address of the server                             |
 | `CTCACHE_HOST_READ_ONLY`          |  ✓   |      | if set, script won't try to push objects to server               |
-| `CTCACHE_PORT`                    |  ✓   |  ✓   | listening port of the server                                     |
+| `CTCACHE_PORT`                    |  ✓   |      | listening port of the server (use `--port` for server)           |
 | `CTCACHE_WEBROOT`                 |      |  ✓   | directory containing static server files                         |
 | `CTCACHE_GCS_BUCKET`              |  ✓   |      | the Google Cloud Storage bucket to store cache remotely          |
 | `CTCACHE_GCS_FOLDER`              |  ✓   |      | the prefix in GCS, w/o leading and trailing `/`                  |

--- a/src/ctcache/clang_tidy_cache_server.py
+++ b/src/ctcache/clang_tidy_cache_server.py
@@ -887,8 +887,12 @@ def ctc_cache(hashstr):
 def ctc_is_cached(hashstr):
     return "true" if clang_tidy_cache.is_cached(hashstr) else "false"
 # ------------------------------------------------------------------------------
-@ctcache_app.route("/purge_cache", methods=['DELETE'])
+@ctcache_app.route("/purge_cache", methods=['GET', 'DELETE'])
 def ctc_purge_cache():
+    # Deny GET if auth_key_writes is configured
+    # In a future update this API cannot be called with a GET request anymore
+    if flask.request.method == 'GET' and clang_tidy_cache.auth_key_writes:
+        return flask.abort(403)
     return str(clang_tidy_cache.do_purge())
 # ------------------------------------------------------------------------------
 @ctcache_app.route("/stats/cached_count")

--- a/src/ctcache/clang_tidy_cache_server.py
+++ b/src/ctcache/clang_tidy_cache_server.py
@@ -887,11 +887,11 @@ def ctc_cache(hashstr):
 def ctc_is_cached(hashstr):
     return "true" if clang_tidy_cache.is_cached(hashstr) else "false"
 # ------------------------------------------------------------------------------
-@ctcache_app.route("/purge_cache", methods=['GET', 'DELETE'])
+@ctcache_app.route("/purge_cache")
 def ctc_purge_cache():
     # Deny GET if auth_key_writes is configured
-    # In a future update this API cannot be called with a GET request anymore
-    if flask.request.method == 'GET' and clang_tidy_cache.auth_key_writes:
+    # In a future update this API can only be called with a DELETE HTTP method
+    if flask.request.method != 'GET' and clang_tidy_cache.auth_key_writes:
         return flask.abort(403)
     return str(clang_tidy_cache.do_purge())
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a simply authentication mechanism for writes.

This allows you to have a public server for reads to speed up developer builds (for example) and do writes on CI where secrets are available.

New environment variable for client: `CTCACHE_AUTH_KEY`, this will be passed as `key` query parameter when making `PUT` requests (i.e. when cache is updated).

`purge_cache` should be called as`DELETE` HTTP method when the auth key is set, in the future it should probably be made DELETE-only, but I kept it for backward compatibility

The auth key can be set up for the server with the `--auth-key-writes` parameter. Allowing for potentially also adding an auth key for reads.