### PR TITLE
fix: do not parse/split "arguments" in `_compiler_args_for`

### DIFF
--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -182,7 +182,7 @@ class ClangTidyCacheOpts:
                         return shlex.split(command["command"])
                     except KeyError:
                         try:
-                            return shlex.split(command["arguments"][0])
+                            return command["arguments"]
                         except:
                             return ["clang-tidy"]
             except FileNotFoundError:


### PR DESCRIPTION
I'm getting errors like
>ERROR:clang_tidy_cache.py:Error executing compile command: #['/usr/bin/clang++-19', '-D__clang_analyzer__=1'].
#b'clang++-19: error: no input files\n'

and nothing is cached (`Cached hashes (local):  0`).

According to documentation:
> arguments: The compile command argv as list of strings. This should run the compilation step for the translation unit file. arguments[0] should be the executable name, such as clang++. Arguments should not be escaped, but ready to pass to execvp().

https://clang.llvm.org/docs/JSONCompilationDatabase.html

And indeed, in our case first entry in compilation database looks like this:
<details>
  <summary>Example</summary>
<pre>
{
  "arguments": [
    "/usr/bin/clang++-19",
    "-std=c++20",
    "-DHAVE_CONFIG_H",
    "-I.",
    "-I../src/config",
    "-DDEBUG_CORE",
    "-DDEBUG_LOCKORDER",
    "-DDEBUG_LOCKCONTENTION",
    "-DRPC_DOC_CHECK",
    "-DABORT_ON_FAILED_ASSUME",
    "-fmacro-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_multiprocess=.",
    "-DHAVE_BUILD_INFO",
    "-DGSL_NO_IOSTREAMS",
    "-DPROVIDE_FUZZ_MAIN_FUNCTION",
    "-I.",
    "-I./minisketch/include",
    "-I./secp256k1/include",
    "-I./univalue/include",
    "-I./leveldb/include",
    "-isystem./dashbls/include",
    "-isystem./dashbls/depends/relic/include",
    "-isystem./dashbls/depends/minialloc/include",
    "-isystem./immer",
    "-isystem",
    "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include",
    "-DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION",
    "-DBOOST_MULTI_INDEX_ENABLE_SAFE_MODE",
    "-isystem",
    "/__w/dash/dash/depends/x86_64-pc-linux-gnu/include",
    "-I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include",
    "-I/__w/dash/dash/depends/x86_64-pc-linux-gnu/include/",
    "-O0",
    "-g3",
    "-ftrapv",
    "-fdebug-prefix-map=/__w/dash/dash/build-ci/dashcore-linux64_multiprocess=.",
    "-Wall",
    "-Wextra",
    "-Wgnu",
    "-Wformat",
    "-Wformat-security",
    "-Wreorder",
    "-Wvla",
    "-Wshadow-field",
    "-Wthread-safety",
    "-Wloop-analysis",
    "-Wredundant-decls",
    "-Wunused-member-function",
    "-Wdate-time",
    "-Wconditional-uninitialized",
    "-Woverloaded-virtual",
    "-Wsuggest-override",
    "-Wimplicit-fallthrough",
    "-Wunreachable-code",
    "-Wdocumentation",
    "-Wself-assign",
    "-Wno-error=deprecated-literal-operator",
    "-Wno-unused-parameter",
    "-Werror",
    "-gdwarf-4",
    "-pipe",
    "-std=c++20",
    "-O2",
    "-O0",
    "-g0",
    "-Wno-error=documentation",
    "-c",
    "-o",
    "libbitcoin_node_a-addrdb.o",
    "addrdb.cpp"
  ],
  "directory": "/__w/dash/dash/build-ci/dashcore-linux64_multiprocess/src",
  "file": "/__w/dash/dash/build-ci/dashcore-linux64_multiprocess/src/addrdb.cpp",
  "output": "/__w/dash/dash/build-ci/dashcore-linux64_multiprocess/src/libbitcoin_node_a-addrdb.o"
}
</pre>
</details>

Applying this patch solves the issue (`Cached hashes (local):  780`).