### PR TITLE
fix: stats read() and clear() skipping 16 directories due to zero-padding mismatch

### DIFF
--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -646,7 +646,7 @@ class ClangTidyCacheStats:
     def read(self):
         hits, misses = 0, 0
         for i in range(0, 256):
-            digest = f'{i:x}'
+            digest = f'{i:02x}'
             file = self.stats_file(digest)
             if os.path.isfile(file):
                 h, m = self._read(file)
@@ -704,7 +704,7 @@ class ClangTidyCacheStats:
     # --------------------------------------------------------------------------
     def clear(self):
         for i in range(0, 256):
-            digest = f'{i:x}'
+            digest = f'{i:02x}'
             file = self.stats_file(digest)
             if os.path.isfile(file):
                 os.unlink(file)


### PR DESCRIPTION
The ClangTidyCacheStats.read() and clear() methods were missing stats from directories 00-0f (~6% of all cache operations) due to a hex formatting mismatch.

When writing stats, digest[:2] creates zero-padded paths like "00", "0f". When reading/clearing stats, f'{i:x}' created non-padded hex like "0", "f" for values 0-15, causing lookups in wrong directories.

This meant:
- read() underreported hits/misses by ~6%
- clear() left ~6% of stats files undeleted

Fixed by changing f'{i:x}' to f'{i:02x}' in both methods to match the zero-padded directory structure used throughout the codebase.

| | Before | After |
|-|-|-|
| `--show-stats` | <pre>Hit count (local):      724<br/>Miss count (local):     0<br/>Miss rate (local):      0 %<br/>Cached hashes (local):  784</pre> | <pre>Hit count (local):      784<br/>Miss count (local):     0<br/>Miss rate (local):      0 %<br/>Cached hashes (local):  784</pre> |
