### PR TITLE
add support for `CTCACHE_BYPASS_FLAGS_REGEX`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ variables:
 | `CTCACHE_DEBUG`                   |  ✓   |      | enables debugging output                                         |
 | `CTCACHE_DIR`                     |  ✓   |      | the cache storage directory in local mode                        |
 | `CTCACHE_EXCLUDE_HASH_REGEX`      |  ✓   |      | regular expression of hashes that should not be cached           |
+| `CTCACHE_BYPASS_FLAGS_REGEX`      |  ✓   |      | regex of flags that cause bypassing ctcache                      |
 | `CTCACHE_SAVE_OUTPUT`             |  ✓   |      | saves the stdout output of `clang-tidy` in the cache             |
 | `CTCACHE_SAVE_ALL`                |  ✓   |      | save the output even when `clang-tidy` exited with error         |
 | `CTCACHE_KEEP_COMMENTS`           |  ✓   |      | include source comments (e.g. `NOLINT`) in the hash              |

--- a/src/ctcache/clang_tidy_cache.py
+++ b/src/ctcache/clang_tidy_cache.py
@@ -397,6 +397,10 @@ class ClangTidyCacheOpts:
         return os.getenv("CTCACHE_EXCLUDE_HASH_REGEX")
 
     # --------------------------------------------------------------------------
+    def bypass_flags_regex(self) -> str:
+        return os.getenv("CTCACHE_BYPASS_FLAGS_REGEX")
+
+    # --------------------------------------------------------------------------
     def exclude_hash(self, chunk: bytes) -> bool:
         return self.exclude_hash_regex() is not None and \
             re.match(self.exclude_hash_regex(), chunk.decode("utf8"))
@@ -1204,6 +1208,13 @@ def hash_inputs(log, opts):
     if not ct_args and not co_args:
         return None
 
+    bypass_flags_regex = opts.bypass_flags_regex()
+    if bypass_flags_regex:
+        for ct_arg in ct_args:
+            if re.search(bypass_flags_regex, ct_arg):
+                log.debug(f"Skip caching because of {ct_arg}")
+                return None
+
     def _is_src_ext(s):
         exts = [".cppm", ".cpp", ".c", ".cc", ".h", ".hpp", ".cxx"]
         return any(s.lower().endswith(ext) for ext in exts)
@@ -1388,7 +1399,9 @@ def run_clang_tidy_cached(log, opts):
     except Exception as error:
         log.error(str(error))
 
-    log.debug(f"Digest {digest} does not exist in cache. Calling real clang-tidy")
+    if digest:
+        log.debug(f"Digest {digest} does not exist in cache.")
+    log.debug(f"Calling real clang-tidy.")
 
     proc = subprocess.Popen(
         opts.original_args(),


### PR DESCRIPTION
If any clang-tidy flag matches the given regex in env variable `CTCACHE_BYPASS_FLAGS_REGEX`, caching is bypassed and real clang-tidy is called.

This helps users to control clang-tidy invokations in a generic way if they are not cacheable (e.g. when `-list-checks` or `-dump-config` is used), as it is done by `run-clang-tidy.py` script.