### PR TITLE
Fix age_days histogram rendering

### DIFF
--- a/src/ctcache/clang_tidy_cache_server.py
+++ b/src/ctcache/clang_tidy_cache_server.py
@@ -628,6 +628,7 @@ class ClangTidyCache(object):
         result = dict()
         for hashstr, info in self._cached.items():
             try:
+                age_days = int(round((time.time() - info["insert_time"]) / (24*3600)))
                 try:
                     result[age_days] += 1
                 except KeyError:


### PR DESCRIPTION
Looks like this histogram was accidentally broken in

https://github.com/matus-chochlik/ctcache/commit/f3f311a8a9f5dfd08cf8b2c80a23fedcd76a6f8f#diff-8be37f58fff41428052b2ed8c4ded1c8671e112de154936c97f8cdf71d77b19eL608